### PR TITLE
Add more tests to identifier validations.

### DIFF
--- a/src/identifier.py
+++ b/src/identifier.py
@@ -27,5 +27,4 @@ def validate(inp):
     """
     Validates that a particular string is either a valid UUID or not a valid UUID.
     """
-    m = re.match(REG_EX, inp)
-    return m is not None and m.group(0) != ""
+    return re.search(REG_EX, inp, re.IGNORECASE) is not None

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -15,11 +15,28 @@
 import unittest
 import identifier
 
+
 class TestCore(unittest.TestCase):
+    def test_valid_identifiers(self):
+        # UUID1.
+        self.assertTrue(identifier.validate('70e7cfc6-def7-11e8-bb65-10e7c6792ac1'))
 
-    def test_identifier(self):
-        i = identifier.identifier()
-        self.assertTrue(identifier.validate(i))   
+        # UUID3.
+        self.assertTrue(identifier.validate('a402d082-1bb6-38ce-b44e-953fd8610fac'))
 
-    def test_validate(self):
-        self.assertFalse(identifier.validate("dfasfdfsadfds"))   
+        # UUID4.
+        self.assertTrue(identifier.validate('9c189dd1-a4d3-4b3f-ba08-37fc962dc9c9'))
+
+        # UUID5.
+        self.assertTrue(identifier.validate('76c439e1-dfc9-50ab-a06a-d70afa21bb2f'))
+
+        # UUID are case insensitive.
+        self.assertTrue(identifier.validate('9C189DD1-A4D3-4B3F-BA08-37FC962DC9C9'))
+
+    def test_invalid_identifier_bad_version(self):
+        # Not a valid UUID identifier (the third group should start with 1, 2, 3, 4 or 5).
+        self.assertFalse(identifier.validate('9c189dd1-a4d3-Xb3f-ba08-37fc962dc9c9'))
+
+    def test_invalid_identifier_format(self):
+        # Bad UUID format
+        self.assertFalse(identifier.validate("dfasfdfsadfds"))


### PR DESCRIPTION
Change the regexp in order to be more strict and accept just UUID4:

Version 4 UUIDs have the form xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
where x is any hexadecimal digit and y is one of 8, 9, A, or B.

Also:
* Make tests pass with uppercase UUIDs
* A little bit of refactoring.