### PR TITLE
Fix file open and unicode decode in taxonomy_units.py

### DIFF
--- a/oblib/taxonomy_units.py
+++ b/oblib/taxonomy_units.py
@@ -17,6 +17,7 @@ import xml.sax
 import taxonomy
 import constants
 import os
+import sys
 
 class _TaxonomyUnitsHandler(xml.sax.ContentHandler):
     """Loads Taxonomy Units from the units type registry file."""
@@ -81,8 +82,13 @@ class TaxonomyUnits(object):
         tax = _TaxonomyUnitsHandler()
         parser = xml.sax.make_parser()
         parser.setContentHandler(tax)
-        with open(fn, 'r', encoding='utf8', errors='ignore') as infile:
-            parser.parse(infile)
+        if sys.version_info[0] < 3:
+            # python 2.x
+            with open(fn, 'r') as infile:
+                parser.parse(infile)
+        else:
+            with open(fn, 'r', encoding='utf8', errors='ignore') as infile:
+                parser.parse(infile)
         return tax.units()
 
     def _load_units(self):

--- a/oblib/taxonomy_units.py
+++ b/oblib/taxonomy_units.py
@@ -16,7 +16,7 @@ import xml.sax
 
 import taxonomy
 import constants
-
+import os
 
 class _TaxonomyUnitsHandler(xml.sax.ContentHandler):
     """Loads Taxonomy Units from the units type registry file."""
@@ -81,11 +81,13 @@ class TaxonomyUnits(object):
         tax = _TaxonomyUnitsHandler()
         parser = xml.sax.make_parser()
         parser.setContentHandler(tax)
-        parser.parse(open(constants.SOLAR_TAXONOMY_DIR + fn))
+        parser.parse(open(fn))
         return tax.units()
 
     def _load_units(self):
-        units = self._load_units_file("/external/utr.xml")
+        pathname = os.path.join(constants.SOLAR_TAXONOMY_DIR, "external")
+        filename = "utr.xml"
+        units = self._load_units_file(os.path.join(pathname, filename))
         return units
 
     def units(self):

--- a/oblib/taxonomy_units.py
+++ b/oblib/taxonomy_units.py
@@ -81,7 +81,8 @@ class TaxonomyUnits(object):
         tax = _TaxonomyUnitsHandler()
         parser = xml.sax.make_parser()
         parser.setContentHandler(tax)
-        parser.parse(open(fn))
+        with open(fn, 'r', encoding='utf8', errors='ignore') as infile:
+            parser.parse(infile)
         return tax.units()
 
     def _load_units(self):


### PR DESCRIPTION
File open now uses os.join for cross-platform compatibility.

Fixed charmap issue when reading units taxonomy 