### PR TITLE
Combine is_unit and is_unit2

### DIFF
--- a/oblib/data_model.py
+++ b/oblib/data_model.py
@@ -976,10 +976,7 @@ class OBInstance(object):
 
         if "unit_name" in kwargs:
             unit_name = kwargs.pop("unit_name")
-            unit = self.tu.get_unit(unit_name)
-        else:
-            unit_name = None
-            unit = None
+            valid_unit_name = self.tu.is_unit(unit_name)
 
         if "precision" in kwargs:
             precision = kwargs.pop("precision")
@@ -1011,7 +1008,7 @@ class OBInstance(object):
                 "Insufficient context for {}".format(concept_name))
 
         # Check unit type:
-        if not self._dev_validation_off and not unit:
+        if not self._dev_validation_off and not valid_unit_name:
             raise OBUnitException(
                 "{} is not a valid unit name for {}".format(unit_name, concept_name))
 

--- a/oblib/data_model.py
+++ b/oblib/data_model.py
@@ -138,7 +138,7 @@ class Hypercube(object):
                     if axis.domain == relation['from']:
                         member = relation['to']
                         axis.domainMembers.append( member )
-        
+
 
     def get_name(self):
         """Return table name."""
@@ -207,10 +207,10 @@ class Hypercube(object):
         axis = self._axes[dimensionName]
         if axis.domain is not None:
             return axis.domain
-        
+
         concept = self._axes[dimensionName].concept
         domain_ref = concept.get_details("typed_domain_ref")
-        
+
         if domain_ref is not None:
             # The typed_domain_ref metadata property will contain something like
             #    "#solar_ProductIdentifierDomain"  which is actually an internal link
@@ -450,7 +450,7 @@ class Fact(object):
         Units is a string naming the unit, for example "kWh"
         Value is a string, integer, or float
         Decimals is used only for float types, it is the number of
-        digits 
+        digits
         """
         # in case of xml the context ID will be rendered in the fact tag.
         # in case of json the contexts' attributes will be copied to the
@@ -587,7 +587,7 @@ class Concept(object):
             if value in ["true", "false", "True", "False"]:
                 return True
             return False
-        
+
         if myType == "xbrli:decimalItemType":
             try:
                 value = float( value )
@@ -673,7 +673,7 @@ class OBInstance(object):
         object.
 
         An optional flag ("dev_validation_off") can be set to turn validation
-        rules off during development.  This should not be used during a release.   
+        rules off during development.  This should not be used during a release.
         """
         self.ts = taxonomy.semantic
         self.tu = taxonomy.units
@@ -909,7 +909,7 @@ class OBInstance(object):
                          "xbrli:anyURIItemType"]
         # There is type-checking we can do for these unitless types but we'll handle
         # it elsewhere
-        
+
         required_type = self.get_concept(concept).get_details("type_name")
         if required_type in unitlessTypes:
             if unit_id is None:
@@ -930,10 +930,11 @@ class OBInstance(object):
                 "No unit given for concept {}, requires type {}".format(
                     concept, required_type))
 
-        unit = self.tu.is_unit2(unit_id)
-        if unit is None:
+        unit = self.tu.get_unit(unit_id)
+        if not unit:
             raise OBNotFoundException(
-                "There is no unit ID={} in the taxonomy.".format(unit_id))
+                "There is no unit with unit_id={} in the taxonomy."
+                 .format(unit_id))
 
         # TODO: utr.xml has unqualified type names, e.g. "frequencyItemType" and we're looking
         # for a qualified type name e.g. "num-us:frequencyItemType". Should we assume that if
@@ -950,26 +951,32 @@ class OBInstance(object):
 
     def set(self, concept_name, value, **kwargs):
         """
-        Adds a fact to the document. The concept_name and the context
-        together identify the fact to set, and the value will be stored for
-        that fact.
-        If concept_name and context are identical to a previous call, the old fact
-        will be overwritten. Otherwise, a new fact is created.
-        acceptable keyword args:
-        unit_nam = a string naming a unit
-        precision = <number of places past the decimal pt>(for decimal values only)
-        context = a Context object
+        Adds a fact to the document.
 
-        can be supplied as separate keyword args instead of context object:
-        duration = "forever" or {"start": <date>, "end": <date>}
-        instant = <date>
-        entity = <entity name>
-        *Axis = <value>  (the name of any Axis in a table in this entrypoint)
+        The concept_name and the context together identify the fact to set,
+        and the value will be stored for that fact. If concept_name and context
+        match a fact already in the document, the old fact will be overwritten.
+        Otherwise, a new fact is created.
+
+        Args:
+            unit_name : string
+                a string naming a unit
+            precision : int
+                number of places past the decimal point (for decimal type only)
+            context : Context
+                can be specified by kwargs duration, instant and entity
+            duration : str or dict
+                "forever" or {"start": <datetime>, "end": <datetime>}
+            instant : datetime
+            entity : str
+                entity name
+            *Axis = <value> (not implemented)
+                the name of any Axis in a table in this entrypoint
         """
 
         if "unit_name" in kwargs:
             unit_name = kwargs.pop("unit_name")
-            valid_unit_name = self.tu.is_unit(unit_name=unit_name)
+            unit = self.tu.get_unit(unit_name)
         else:
             unit_name = None
 
@@ -983,9 +990,10 @@ class OBInstance(object):
 
         if "context" in kwargs:
             context = kwargs.pop("context")
-        elif len(list(kwargs.keys())) > 0:
+        elif set("duration", "instant", "entity") in kwargs.keys():
             # turn the remaining keyword args into a Context object -- this
             # is just syntactic sugar to make this method easier to call.
+            # TODO this block will not work
             period = concept.get_details("period_type")
             if period not in kwargs and period in self._default_context:
                 kwargs[period.value] = self._default_context[period]
@@ -1002,16 +1010,16 @@ class OBInstance(object):
                 "Insufficient context for {}".format(concept_name))
 
         # Check unit type:
-        if not self._dev_validation_off and not self._is_valid_unit(concept_name, unit_name):
+        if not self._dev_validation_off and not unit:
             raise OBUnitException(
-                "{} is an invalid unit type for {}".format(unit_name, concept_name))
-        
+                "{} is not a valid unit name for {}".format(unit_name, concept_name))
+
         # check datatype of given value against concept
         if not self._dev_validation_off and not concept.validate_datatype(value):
             raise OBTypeException(
                 "{} is the wrong datatype for {}".format(value, concept_name))
 
-        
+
         table = self.get_table_for_concept(concept_name)
         context = table.store_context(context) # dedupes, assigns ID
 
@@ -1025,7 +1033,7 @@ class OBInstance(object):
         if not context.get_id() in self.facts[table.get_name()]:
             self.facts[table.get_name()][context.get_id()] = {}
         # TODO simplify above with defaultdict
-        
+
         self.facts[table.get_name()][context.get_id()][concept_name] = f
         # Or: we could keep facts in a flat list, and get() could look them
         # up by getting context from hypercube and getting fact from context
@@ -1071,7 +1079,7 @@ class OBInstance(object):
                 for fact in list(context_dict.values()):
                     all_facts.append(fact)
         return all_facts
-    
+
     def _make_unit_tag(self, unit_id):
         """
         Return an XML tag for a unit (such as kw, kwh, etc). Fact tags can

--- a/oblib/data_model.py
+++ b/oblib/data_model.py
@@ -991,7 +991,7 @@ class OBInstance(object):
 
         if "context" in kwargs:
             context = kwargs.pop("context")
-        elif set(["duration", "instant", "entity"]) in kwargs.keys():
+        elif all([k in kwargs for k in {"duration", "instant", "entity"}]):
             # turn the remaining keyword args into a Context object -- this
             # is just syntactic sugar to make this method easier to call.
             # TODO this block will not work

--- a/oblib/data_model.py
+++ b/oblib/data_model.py
@@ -991,7 +991,7 @@ class OBInstance(object):
 
         if "context" in kwargs:
             context = kwargs.pop("context")
-        elif all([k in kwargs for k in {"duration", "instant", "entity"}]):
+        elif len(list(kwargs.keys())) > 0:
             # turn the remaining keyword args into a Context object -- this
             # is just syntactic sugar to make this method easier to call.
             # TODO this block will not work

--- a/oblib/data_model.py
+++ b/oblib/data_model.py
@@ -990,7 +990,7 @@ class OBInstance(object):
 
         if "context" in kwargs:
             context = kwargs.pop("context")
-        elif set("duration", "instant", "entity") in kwargs.keys():
+        elif set(["duration", "instant", "entity"]) in kwargs.keys():
             # turn the remaining keyword args into a Context object -- this
             # is just syntactic sugar to make this method easier to call.
             # TODO this block will not work

--- a/oblib/data_model.py
+++ b/oblib/data_model.py
@@ -979,6 +979,7 @@ class OBInstance(object):
             unit = self.tu.get_unit(unit_name)
         else:
             unit_name = None
+            unit = None
 
         if "precision" in kwargs:
             precision = kwargs.pop("precision")

--- a/oblib/data_model.py
+++ b/oblib/data_model.py
@@ -977,6 +977,9 @@ class OBInstance(object):
         if "unit_name" in kwargs:
             unit_name = kwargs.pop("unit_name")
             valid_unit_name = self.tu.is_unit(unit_name)
+        else:
+            unit_name = None
+            valid_unit_name = False
 
         if "precision" in kwargs:
             precision = kwargs.pop("precision")
@@ -1008,7 +1011,7 @@ class OBInstance(object):
                 "Insufficient context for {}".format(concept_name))
 
         # Check unit type:
-        if not self._dev_validation_off and not valid_unit_name:
+        if not self._dev_validation_off and not  self._is_valid_unit(concept_name, unit_name):
             raise OBUnitException(
                 "{} is not a valid unit name for {}".format(unit_name, concept_name))
 

--- a/oblib/taxonomy_units.py
+++ b/oblib/taxonomy_units.py
@@ -113,16 +113,54 @@ class TaxonomyUnits(object):
         """Return a dict of the form {unit_name: unit_id}"""
         return {self._units[k].unit_name: k for k in self._units.keys()}
 
-    def is_unit(self, unit):
+    def is_unit(self, unit_str):
         """
-        Return True if unit is the unit_id, unit_name or id of a unit in the
-        taxonomy, False otherwise.
+        Return True if unit_str is the unit_id, unit_name or id of a unit in
+        the taxonomy, False otherwise.
 
         Args:
-            unit : string
+            unit_str : string
+                can be unit_id, unit_name or id
 
         Returns boolean
         """
-        return (unit in self._units.keys() or \
-                unit in self._by_id.keys() or \
-                unit in self._by_unit_name.keys())
+        return (unit_str in self._units.keys() or \
+                unit_str in self._by_id().keys() or \
+                unit_str in self._by_unit_name().keys())
+
+    def get_unit(self, unit_str):
+        """
+        Returns the unit with unit_id, unit_name or id is given by unit_str.
+
+        Args:
+            unit_str : string
+                can be unit_id, unit_name or id
+
+        Returns:
+            unit : dict
+
+        Raises:
+            KeyError if unit_str is not in the taxonomy
+        """
+        found = False
+        if self.is_unit(unit_str):
+            # find unit_id
+            try:
+                unit = self._units[unit_str]
+                found = True
+            except:
+                if unit_str in self._by_id():
+                    unit_id = self._by_id()[unit_str]
+                    unit = self._units[unit_id]
+                    found = True
+                elif unit_str in self._by_unit_name():
+                    unit_id = self._by_unit_name[unit_str]
+                    unit = self._units[unit_id]
+                    found = True
+
+        if not found:
+            raise KeyError("{} is not a valid unit_id, unit_name or id"
+                            .format(unit_str))
+            return None
+        else:
+            return unit

--- a/oblib/taxonomy_units.py
+++ b/oblib/taxonomy_units.py
@@ -102,33 +102,27 @@ class TaxonomyUnits(object):
         return units
 
     def get_all_units(self):
-        """Return a map and sublists of all units."""
+        """Return a dict of all units with unit_id as primary key."""
         return self._units
 
-    def is_unit(self, **kwargs):
-        """
-        Validate that a unit is in the taxonomy based on its unit_id or
-        unit_name.
-        """
-        if "unit_id" in kwargs:
-            unit_id = kwargs.pop("unit_id")
-            return unit_id in self._units
-        elif "unit_name" in kwargs:
-            unit_name = kwargs.pop("unit_name")
-            valid_names = [self._units[k].unit_name for k in
-                           self._units.keys()]
-            return unit_name in valid_names
-        else:
-            return False
+    def _by_id(self):
+        """Return a dict of the form {id: unit_id}"""
+        return {self._units[k].id: k for k in self._units.keys()}
 
-    def is_unit2(self, unit_id):
-        """
-        Return a unit.
+    def _by_unit_name(self):
+        """Return a dict of the form {unit_name: unit_id}"""
+        return {self._units[k].unit_name: k for k in self._units.keys()}
 
-        Returns an unit given a unit_id or None if unit_id does not
-        exist in the taxonomy.
+    def is_unit(self, unit):
         """
-        if unit_id in self._units:
-            return self._units[unit_id]
-        else:
-            return None
+        Return True if unit is the unit_id, unit_name or id of a unit in the
+        taxonomy, False otherwise.
+
+        Args:
+            unit : string
+
+        Returns boolean
+        """
+        return (unit in self._units.keys() or \
+                unit in self._by_id.keys() or \
+                unit in self._by_unit_name.keys())

--- a/oblib/taxonomy_units.py
+++ b/oblib/taxonomy_units.py
@@ -154,7 +154,7 @@ class TaxonomyUnits(object):
                     unit = self._units[unit_id]
                     found = True
                 elif unit_str in self._by_unit_name():
-                    unit_id = self._by_unit_name[unit_str]
+                    unit_id = self._by_unit_name()[unit_str]
                     unit = self._units[unit_id]
                     found = True
 

--- a/oblib/taxonomy_units.py
+++ b/oblib/taxonomy_units.py
@@ -22,6 +22,7 @@ import util
 import os
 import sys
 
+
 class _TaxonomyUnitsHandler(xml.sax.ContentHandler):
     """Loads Taxonomy Units from the units type registry file."""
 

--- a/oblib/tests/test_taxonomy_units.py
+++ b/oblib/tests/test_taxonomy_units.py
@@ -79,6 +79,6 @@ class TestTaxonomyUnits(unittest.TestCase):
         self.assertEqual(unit, unit3)
 
     def test_get_all_units(self):
-        units = self.get_all_units()
+        units = tax.get_all_units()
         self.assertIsInstance(units, dict)
         self.assertEqual(len(units.keys()), 296)

--- a/oblib/tests/test_taxonomy_units.py
+++ b/oblib/tests/test_taxonomy_units.py
@@ -27,21 +27,23 @@ class TestTaxonomyUnits(unittest.TestCase):
         self.assertEqual(len(tax.get_all_units()), 296)
 
     def test_validate_unit(self):
-        self.assertTrue(tax.is_unit(unit_id="acre"))
-        self.assertTrue(tax.is_unit(unit_id="oz"))
-        self.assertTrue(tax.is_unit(unit_id="rad"))
-        self.assertFalse(tax.is_unit(unit_id="acrre"))
-        self.assertFalse(tax.is_unit(unit_id="ozz"))
-        self.assertFalse(tax.is_unit(unit_id="rrad"))
-        self.assertTrue(tax.is_unit(unit_name="Acre"))
-        self.assertTrue(tax.is_unit(unit_name="Ounce"))
-        self.assertTrue(tax.is_unit(unit_name="Radian"))
-        self.assertFalse(tax.is_unit(unit_name="acrre"))
-        self.assertFalse(tax.is_unit(unit_name="ozz"))
-        self.assertFalse(tax.is_unit(unit_name="rrad"))
+        self.assertTrue(tax.is_unit("acre"))
+        self.assertTrue(tax.is_unit("oz"))
+        self.assertTrue(tax.is_unit("rad"))
+        self.assertFalse(tax.is_unit("acrre"))
+        self.assertFalse(tax.is_unit("ozz"))
+        self.assertFalse(tax.is_unit("rrad"))
+        self.assertTrue(tax.is_unit("Acre"))
+        self.assertTrue(tax.is_unit("Ounce"))
+        self.assertTrue(tax.is_unit("Radian"))
+        self.assertFalse(tax.is_unit("acrre"))
+        self.assertFalse(tax.is_unit("ozz"))
+        self.assertFalse(tax.is_unit("rrad"))
+        self.assertTrue(tax.is_unit("u00004"))
+        self.assertFalse(tax.is_unit("x0004"))
 
     def test_unit(self):
-        unit = tax.is_unit2("VAh")
+        unit = tax.get_allunits()["VAh"]
 
         # Test data types
         # TODO: checks for strings are commented out for Python 2.7 which fails

--- a/oblib/tests/test_taxonomy_units.py
+++ b/oblib/tests/test_taxonomy_units.py
@@ -26,7 +26,7 @@ class TestTaxonomyUnits(unittest.TestCase):
     def test_taxonomy_units(self):
         self.assertEqual(len(tax.get_all_units()), 296)
 
-    def test_validate_unit(self):
+    def test_is_unit(self):
         self.assertTrue(tax.is_unit("acre"))
         self.assertTrue(tax.is_unit("oz"))
         self.assertTrue(tax.is_unit("rad"))
@@ -42,8 +42,8 @@ class TestTaxonomyUnits(unittest.TestCase):
         self.assertTrue(tax.is_unit("u00004"))
         self.assertFalse(tax.is_unit("x0004"))
 
-    def test_unit(self):
-        unit = tax.get_allunits()["VAh"]
+    def test_get_unit(self):
+        unit = tax.get_unit("VAh")
 
         # Test data types
         # TODO: checks for strings are commented out for Python 2.7 which fails
@@ -72,3 +72,13 @@ class TestTaxonomyUnits(unittest.TestCase):
         self.assertEqual(unit.base_standard, taxonomy.BaseStandard.customary)
         self.assertEqual(unit.status, taxonomy.UnitStatus.cr)
         self.assertEqual(unit.version_date, datetime.date(2017, 7, 12))
+
+        unit2 = tax.get_unit("u00291")
+        self.assertEqual(unit, unit2)
+        unit3 = tax.get_unit("Volt-ampere-hours")
+        self.assertEqual(unit, unit3)
+
+    def test_get_all_units(self):
+        units = self.get_all_units()
+        self.assertIsInstance(units, dict)
+        self.assertEqual(len(units.keys()), 296)

--- a/scripts/cli/cli.py
+++ b/scripts/cli/cli.py
@@ -61,7 +61,7 @@ def convert(args):
     if ff is None:
         print("Unable to determine file format.  Conversion not processed.")
         sys.exit(1)
-    
+
     try:
         p.convert(args.infile, args.outfile, ff, entrypoint_name=args.entrypoint)
     except ValidationErrors as errors:
@@ -117,7 +117,7 @@ def list_concept_info(args):
 
 
 def list_unit_info(args):
-    unit = tax.units.is_unit2(args.unit)
+    unit = tax.units.get_unit(args.unit)
     if unit is not None:
         print("Id:                ", unit.id)
         print("Unit Id:           ", unit.unit_id)
@@ -228,7 +228,7 @@ def list_units_details(args):
         print("Id, Unit ID, Name, nsUnit, Item Type, Item Type Dt, Symbol, Base Std, Status, Ver Dt, Definition")
 
         for unit_id in tax.units.get_all_units():
-                unit = tax.units.is_unit2(unit_id)
+                unit = tax.units.get_unit(unit_id)
                 print('%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s' %
                        (unit.id, unit.unit_id, unit.unit_name, unit.ns_unit, unit.item_type,
                        unit.item_type_date, unit.symbol, unit.base_standard, unit.version_date,
@@ -241,7 +241,7 @@ def list_units_details(args):
                 (DASHES, DASHES, DASHES, DASHES, DASHES, DASHES, DASHES, DASHES, DASHES, DASHES, DASHES))
 
         for unit_id in tax.units.get_all_units():
-                unit = tax.units.is_unit2(unit_id)
+                unit = tax.units.get_unit(unit_id)
                 print('%6s %10s %40s %35s %16s %10s %6s %9s %10s %8s %1s' %
                        (unit.id, unit.unit_id, unit.unit_name, unit.ns_unit, unit.item_type,
                        unit.item_type_date, unit.symbol, unit.base_standard, unit.version_date,
@@ -254,7 +254,7 @@ def list_types(args):
     names.sort()
     for name in names:
         print(name)
-        
+
 
 def validate_concept(args):
     print("Valid:", tax.semantic.is_concept(args.concept))
@@ -293,7 +293,7 @@ def validate_generic_role(args):
 
 
 def validate_unit(args):
-    print("Valid:", tax.units.is_unit(unit_id=args.generic_unit))
+    print("Valid:", tax.units.is_unit(args.generic_unit))
 
 
 def version(args):


### PR DESCRIPTION
Proposed behavior of combined `is_unit` is to return True if the input string corresponds to an id, unit_id or unit_name in the taxonomy. Changes are not propagated into `data_model.set`.  @jonoxia 

Closes #89 