### PR TITLE
Add details kwarg to get_entrypoint_concept and get_all_concepts, remove get_entrypoint_concept_details and get_all_concepts_details

### DIFF
--- a/oblib/taxonomy_semantic.py
+++ b/oblib/taxonomy_semantic.py
@@ -290,12 +290,45 @@ class TaxonomySemantic(object):
         else:
             return False
 
-    def get_entrypoint_concepts(self, entrypoint):
-        """Return a list of all concepts in an entry point."""
+    def get_entrypoint_concepts(self, entrypoint, details=False):
+        """
+        Return a list of all concepts in the entrypoint, with concept details 
+        (optional).
+
+        Args:
+            entrypoint: str
+                name of the entrypoint
+            details: boolean, default False
+                if True return details for each concept
+
+        Returns:
+            concepts: list
+                elements of the list are concept names
+            details: dict
+                primary key is name from concepts, value is dict of concept
+                details
+        """
+        concepts = None
+        ci = []
         if entrypoint in self._concepts:
-            return self._concepts[entrypoint]
-        else:
-            return None
+            concepts = self._concepts[entrypoint]
+            if details:
+                for concept in concepts:
+                    if concept in self._elements:
+                        ci.append(self._elements[concept])
+                    else:
+                        # TODO: This is now known to be a bug in the taxonomy
+                        # and has been submitted for fix.
+                        # Remove this comment once completed.
+                        # Here are some samples that are not found:
+                        # Warning, concept not found: solar:MeterRatingAccuracy_1
+                        # Warning, concept not found: solar:MeterRevenueGrade_1
+                        # Warning, concept not found: solar:MeterBidirectional_1
+                        # Warning, concept not found: solar:RevenueMeterPowerFactor_1
+                        # Warning, concept not found: solar:InverterPowerLevel10PercentMember_1
+                        # print("Warning, concept not found:", concept)
+                        pass
+        return concepts, ci
 
     def get_entrypoint_relationships(self, entrypoint):
         """
@@ -333,28 +366,31 @@ class TaxonomySemantic(object):
         else:
             return None
 
-    def get_entrypoint_concepts_details(self, entrypoint):
-        """
-        Return concepts from an endpoints.
-
-        Return a list of all concepts and their attributes in an end point.
-        """
-        if entrypoint in self._concepts:
-            ci = []
-            for concept in self._concepts[entrypoint]:
-                if concept in self._elements:
-                    ci.append(self._elements[concept])
-                else:
-                    # TODO: This is now known to be a bug in the taxonomy and has been submitted for fix.
-                    # Remove this comment once completed.
-                    # Here are some samples that are not found:
-                    # Warning, concept not found: solar:MeterRatingAccuracy_1
-                    # Warning, concept not found: solar:MeterRevenueGrade_1
-                    # Warning, concept not found: solar:MeterBidirectional_1
-                    # Warning, concept not found: solar:RevenueMeterPowerFactor_1
-                    # Warning, concept not found: solar:InverterPowerLevel10PercentMember_1
-                    # print("Warning, concept not found:", concept)
-                    pass
-            return ci
-        else:
-            return None
+# =============================================================================
+#     def get_entrypoint_concepts_details(self, entrypoint):
+#         """
+#         Return concepts from an endpoints.
+# 
+#         Return a list of all concepts and their attributes in an end point.
+#         """
+#         if entrypoint in self._concepts:
+#             ci = []
+#             for concept in self._concepts[entrypoint]:
+#                 if concept in self._elements:
+#                     ci.append(self._elements[concept])
+#                 else:
+#                     # TODO: This is now known to be a bug in the taxonomy and has been submitted for fix.
+#                     # Remove this comment once completed.
+#                     # Here are some samples that are not found:
+#                     # Warning, concept not found: solar:MeterRatingAccuracy_1
+#                     # Warning, concept not found: solar:MeterRevenueGrade_1
+#                     # Warning, concept not found: solar:MeterBidirectional_1
+#                     # Warning, concept not found: solar:RevenueMeterPowerFactor_1
+#                     # Warning, concept not found: solar:InverterPowerLevel10PercentMember_1
+#                     # print("Warning, concept not found:", concept)
+#                     pass
+#             return ci
+#         else:
+#             return None
+# 
+# =============================================================================

--- a/oblib/taxonomy_semantic.py
+++ b/oblib/taxonomy_semantic.py
@@ -308,14 +308,14 @@ class TaxonomySemantic(object):
                 primary key is name from concepts, value is dict of concept
                 details
         """
-        concepts = None
-        ci = []
+        concepts = []
         if entrypoint in self._concepts:
             concepts = self._concepts[entrypoint]
             if details:
+                ci = {}
                 for concept in concepts:
                     if concept in self._elements:
-                        ci.append(self._elements[concept])
+                        ci[concept] = self._elements[concept]
                     else:
                         # TODO: This is now known to be a bug in the taxonomy
                         # and has been submitted for fix.
@@ -328,7 +328,8 @@ class TaxonomySemantic(object):
                         # Warning, concept not found: solar:InverterPowerLevel10PercentMember_1
                         # print("Warning, concept not found:", concept)
                         pass
-        return concepts, ci
+                return concepts, ci
+        return concepts
 
     def get_entrypoint_relationships(self, entrypoint):
         """

--- a/oblib/taxonomy_semantic.py
+++ b/oblib/taxonomy_semantic.py
@@ -257,12 +257,15 @@ class TaxonomySemantic(object):
             return self._elements
 
     def get_all_type_names(self):
-        """Return an array of strings representing all data types in elements"""
+        """
+        Return all type names in elements of the taxonomy.
 
-        type_names = []
+        Returns list
+        """
+        type_names = set() # use set to eliminate duplicates
         for e in self._elements:
-            type_names.append(self._elements[e].type_name)
-        return type_names
+            type_names.add(self._elements[e].type_name)
+        return list(type_names)
 
     def is_concept(self, concept):
         """Validate if a concept is present in the Taxonomy."""

--- a/oblib/taxonomy_semantic.py
+++ b/oblib/taxonomy_semantic.py
@@ -240,17 +240,29 @@ class TaxonomySemantic(object):
                 ne[e] = self._elements[e]
         self._elements = ne
 
-    def get_all_concepts_details(self):
-        """Return a map of elements."""
-        return self._elements
+    def get_all_concepts(self, details=False):
+        """
+        Return all concepts in the taxonomy.
+        
+        Args:
+            details : boolean, default False
+
+        Returns:
+            list of concept names if details=False
+            dict of concept details if details=True
+        """
+        if not details:
+            return list(self._concepts)
+        else:
+            return self._elements
 
     def get_all_type_names(self):
         """Return an array of strings representing all data types in elements"""
 
-        type_names = set()
+        type_names = []
         for e in self._elements:
-            type_names.add(self._elements[e].type_name)
-        return list(type_names)
+            type_names.append(self._elements[e].type_name)
+        return type_names
 
     def is_concept(self, concept):
         """Validate if a concept is present in the Taxonomy."""
@@ -353,45 +365,22 @@ class TaxonomySemantic(object):
         return list(self._concepts)
 
     def get_concept_details(self, concept):
-        """Return information on a single concept."""
-        found = False
-        for c in self._concepts:
-            for cc in self._concepts[c]:
-                if cc == concept:
-                    found = True
-                    break
-        if not found:
-            return None
-        if concept in self._elements:
+        """
+        Return information on a single concept.
+
+        Args:
+            concept : str
+                concept name
+
+        Returns:
+            dict containing concept attributes
+
+        Raises:
+            KeyError if concept is not found
+        """
+        if self.is_concept(concept):
             return self._elements[concept]
         else:
+            raise KeyError('{} is not a concept in the taxonomy'.format(concept))
             return None
 
-# =============================================================================
-#     def get_entrypoint_concepts_details(self, entrypoint):
-#         """
-#         Return concepts from an endpoints.
-# 
-#         Return a list of all concepts and their attributes in an end point.
-#         """
-#         if entrypoint in self._concepts:
-#             ci = []
-#             for concept in self._concepts[entrypoint]:
-#                 if concept in self._elements:
-#                     ci.append(self._elements[concept])
-#                 else:
-#                     # TODO: This is now known to be a bug in the taxonomy and has been submitted for fix.
-#                     # Remove this comment once completed.
-#                     # Here are some samples that are not found:
-#                     # Warning, concept not found: solar:MeterRatingAccuracy_1
-#                     # Warning, concept not found: solar:MeterRevenueGrade_1
-#                     # Warning, concept not found: solar:MeterBidirectional_1
-#                     # Warning, concept not found: solar:RevenueMeterPowerFactor_1
-#                     # Warning, concept not found: solar:InverterPowerLevel10PercentMember_1
-#                     # print("Warning, concept not found:", concept)
-#                     pass
-#             return ci
-#         else:
-#             return None
-# 
-# =============================================================================

--- a/oblib/tests/test_taxonomy_semantic.py
+++ b/oblib/tests/test_taxonomy_semantic.py
@@ -72,6 +72,9 @@ class TestTaxonomySemantic(unittest.TestCase):
         self.assertEqual(ci.type_name, "dei:legalEntityIdentifierItemType")
         self.assertEqual(ci.period_type, taxonomy.PeriodType.duration)
 
+        with self.assertRaises(KeyError):
+            _ = tax.get_concept_details("solar:iamnotaconcept")
+
     def test_get_entrypoint_concepts(self):
         concepts = tax.get_entrypoint_concepts("MonthlyOperatingReport")
         self.assertEqual(len(concepts), 84)
@@ -104,8 +107,11 @@ class TestTaxonomySemantic(unittest.TestCase):
 #             self.assertEqual(ci, tax.get_concept_details(ci.id))
 # 
 # =============================================================================
-    def test_get_all_concept_details(self):
-        self.assertIsNotNone(tax.get_all_concepts_details())
+    def test_get_all_concepts(self):
+        self.assertIsNotNone(tax.get_all_concepts())
+        self.assertIsInstance(tax.get_all_concepts(), list)
+        self.assertIsNotNone(tax.get_all_concepts(details=True))
+        self.assertIsNotNone(tax.get_all_concepts(details=True), dict)
 
     def test_get_all_type_names(self):
         self.assertEqual(len(tax.get_all_type_names()), 76)

--- a/oblib/tests/test_taxonomy_semantic.py
+++ b/oblib/tests/test_taxonomy_semantic.py
@@ -76,7 +76,7 @@ class TestTaxonomySemantic(unittest.TestCase):
         concepts = tax.get_entrypoint_concepts("MonthlyOperatingReport")
         self.assertEqual(len(concepts), 84)
         concepts = tax.get_entrypoint_concepts("MonthlyOperatingReort")
-        self.assertEqual(concepts, None)
+        self.assertEqual(concepts, [])
         concepts, details = tax.get_entrypoint_concepts("CutSheet",
                                                         details=True)
         self.assertEqual(len(concepts), 302)

--- a/oblib/tests/test_taxonomy_semantic.py
+++ b/oblib/tests/test_taxonomy_semantic.py
@@ -73,27 +73,37 @@ class TestTaxonomySemantic(unittest.TestCase):
         self.assertEqual(ci.period_type, taxonomy.PeriodType.duration)
 
     def test_get_entrypoint_concepts(self):
-        self.assertEqual(len(tax.get_entrypoint_concepts("MonthlyOperatingReport")), 84)
-        self.assertEqual(tax.get_entrypoint_concepts("MonthlyOperatingReort"), None)
-        self.assertEqual(len(tax.get_entrypoint_concepts("CutSheet")), 302)
-        self.assertEqual(len(tax.get_entrypoint_concepts("Utility")), 8)
+        concepts, _ = tax.get_entrypoint_concepts("MonthlyOperatingReport")
+        self.assertEqual(len(concepts), 84)
+        concepts, _ = tax.get_entrypoint_concepts("MonthlyOperatingReort")
+        self.assertEqual(concepts, None)
+        concepts, details = tax.get_entrypoint_concepts("CutSheet",
+                                                        details=True)
+        self.assertEqual(len(concepts), 302)
+        self.assertEqual(len(details), 297)
+        concepts, details = tax.get_entrypoint_concepts("Utility", True)
+        self.assertEqual(len(concepts), 8)
+        for ci in details:
+            self.assertEqual(ci, tax.get_concept_details(ci.id))
 
         # TODO: SystemInstallation is currently loaded under System.
         # self.assertEqual(len(tax.concepts_ep("SystemInstallationCost")), 10)
 
-    def test_get_entrypoint_concepts_details(self):
-        self.assertEqual(len(tax.get_entrypoint_concepts_details("MonthlyOperatingReport")), 84)
-        self.assertEqual(tax.get_entrypoint_concepts_details("MonthlyOperatingReort"), None)
-        
-        # TODO: 302 is expected but 297 returned, seeking info on why this is from XBRL.
-        # self.assertEqual(len(tax.concepts_info_ep("CutSheet")), 302)
-        self.assertEqual(len(tax.get_entrypoint_concepts_details("CutSheet")), 297)
-
-        self.assertEqual(len(tax.get_entrypoint_concepts_details("Utility")), 8)
-
-        for ci in tax.get_entrypoint_concepts_details("Utility"):
-            self.assertEqual(ci, tax.get_concept_details(ci.id))
-
+# =============================================================================
+#     def test_get_entrypoint_concepts_details(self):
+#         self.assertEqual(len(tax.get_entrypoint_concepts_details("MonthlyOperatingReport")), 84)
+#         self.assertEqual(tax.get_entrypoint_concepts_details("MonthlyOperatingReort"), None)
+#         
+#         # TODO: 302 is expected but 297 returned, seeking info on why this is from XBRL.
+#         # self.assertEqual(len(tax.concepts_info_ep("CutSheet")), 302)
+#         self.assertEqual(len(tax.get_entrypoint_concepts_details("CutSheet")), 297)
+# 
+#         self.assertEqual(len(tax.get_entrypoint_concepts_details("Utility")), 8)
+# 
+#         for ci in tax.get_entrypoint_concepts_details("Utility"):
+#             self.assertEqual(ci, tax.get_concept_details(ci.id))
+# 
+# =============================================================================
     def test_get_all_concept_details(self):
         self.assertIsNotNone(tax.get_all_concepts_details())
 

--- a/oblib/tests/test_taxonomy_semantic.py
+++ b/oblib/tests/test_taxonomy_semantic.py
@@ -83,8 +83,8 @@ class TestTaxonomySemantic(unittest.TestCase):
         self.assertEqual(len(details), 297)
         concepts, details = tax.get_entrypoint_concepts("Utility", True)
         self.assertEqual(len(concepts), 8)
-        for ci in details:
-            self.assertEqual(ci, tax.get_concept_details(ci.id))
+        for ci in concepts:
+            self.assertEqual(details[ci], tax.get_concept_details(ci))
 
         # TODO: SystemInstallation is currently loaded under System.
         # self.assertEqual(len(tax.concepts_ep("SystemInstallationCost")), 10)

--- a/oblib/tests/test_taxonomy_semantic.py
+++ b/oblib/tests/test_taxonomy_semantic.py
@@ -73,9 +73,9 @@ class TestTaxonomySemantic(unittest.TestCase):
         self.assertEqual(ci.period_type, taxonomy.PeriodType.duration)
 
     def test_get_entrypoint_concepts(self):
-        concepts, _ = tax.get_entrypoint_concepts("MonthlyOperatingReport")
+        concepts = tax.get_entrypoint_concepts("MonthlyOperatingReport")
         self.assertEqual(len(concepts), 84)
-        concepts, _ = tax.get_entrypoint_concepts("MonthlyOperatingReort")
+        concepts = tax.get_entrypoint_concepts("MonthlyOperatingReort")
         self.assertEqual(concepts, None)
         concepts, details = tax.get_entrypoint_concepts("CutSheet",
                                                         details=True)

--- a/scripts/cli/cli.py
+++ b/scripts/cli/cli.py
@@ -142,14 +142,14 @@ def list_ep(args):
 def list_ep_concepts_info(args):
 
     if csv:
-        concepts = tax.semantic.get_entrypoint_concepts_details(args.ep)
+        concepts = tax.semantic.get_entrypoint_concepts(args.ep, details=True)
         print("Id, Name, Abstract, Nillable, Period Indicator, Substitution Group", "Type", "Period Type")
         for c in concepts:
                 print('%s, %s, %s, %s, %s, %s, %s, %s' %
                 (c.id, c.name, c.abstract, c.nillable, c.period_independent,
                 c.substitution_group, c.type_name, c.period_type))
     else:
-        concepts = tax.semantic.get_entrypoint_concepts_details(args.ep)
+        concepts = tax.semantic.get_entrypoint_concepts(args.ep, details=True)
         print('%85s %80s %8s %8s %10s %20s %28s %8s' %
                 ("Id", "Name", "Abstract", "Nillable", "Period Ind", "Substitution Group", "Type",
                 "Per Type"))

--- a/scripts/cli/cli.py
+++ b/scripts/cli/cli.py
@@ -142,23 +142,28 @@ def list_ep(args):
 def list_ep_concepts_info(args):
 
     if csv:
-        concepts = tax.semantic.get_entrypoint_concepts(args.ep, details=True)
-        print("Id, Name, Abstract, Nillable, Period Indicator, Substitution Group", "Type", "Period Type")
+        concepts, details = tax.semantic.get_entrypoint_concepts(args.ep,
+                                                                 details=True)
+        print("Id, Name, Abstract, Nillable, Period Indicator, "
+              "Substitution Group, Type, Period Type")
         for c in concepts:
-                print('%s, %s, %s, %s, %s, %s, %s, %s' %
-                (c.id, c.name, c.abstract, c.nillable, c.period_independent,
-                c.substitution_group, c.type_name, c.period_type))
+            d = details[c]
+            print('%s, %s, %s, %s, %s, %s, %s, %s' %
+            (d.id, d.name, d.abstract, d.nillable, d.period_independent,
+            d.substitution_group, d.type_name, d.period_type))
     else:
-        concepts = tax.semantic.get_entrypoint_concepts(args.ep, details=True)
+        concepts, details = tax.semantic.get_entrypoint_concepts(args.ep,
+                                                                 details=True)
         print('%85s %80s %8s %8s %10s %20s %28s %8s' %
-                ("Id", "Name", "Abstract", "Nillable", "Period Ind", "Substitution Group", "Type",
-                "Per Type"))
+                ("Id", "Name", "Abstract", "Nillable", "Period Ind",
+                 "Substitution Group", "Type", "Period Type"))
         print('%0.85s %0.80s %0.8s %0.8s %0.10s %0.20s %0.28s %0.8s' %
                 (DASHES, DASHES, DASHES, DASHES, DASHES, DASHES, DASHES, DASHES))
         for c in concepts:
-                print('%85s %80s %8s %8s %10s %20s %28s %8s' %
-                (c.id, c.name, c.abstract, c.nillable, c.period_independent,
-                c.substitution_group, c.type_name, c.period_type))
+            d = details[c]
+            print('%85s %80s %8s %8s %10s %20s %28s %8s' %
+            (d.id, d.name, d.abstract, d.nillable, d.period_independent,
+            d.substitution_group, d.type_name, d.period_type))
 
 
 def list_concepts(args):


### PR DESCRIPTION
Closes #91.

Adds details kwarg to get_entrypoint_concept and get_all_concepts.
Remove get_entrypoint_concept_details and get_all_concepts_details, functionality provided through details=True