### PR TITLE
Add attribute name kwarg to TaxonomyUnits.is_unit, .get_unit

### DIFF
--- a/oblib/taxonomy_units.py
+++ b/oblib/taxonomy_units.py
@@ -192,6 +192,8 @@ class TaxonomyUnits(object):
                 raise ValueError("{} is not a valid unit_id, unit_name or id"
                                 .format(unit_str))
                 return None
+            else:
+                return unit
 
         elif attr not in {'unit_id', 'unit_name', 'id'}:
             raise ValueError('{} is not a recognized unit attribute'

--- a/oblib/taxonomy_units.py
+++ b/oblib/taxonomy_units.py
@@ -113,54 +113,108 @@ class TaxonomyUnits(object):
         """Return a dict of the form {unit_name: unit_id}"""
         return {self._units[k].unit_name: k for k in self._units.keys()}
 
-    def is_unit(self, unit_str):
+    def is_unit(self, unit_str, attr=None):
         """
         Return True if unit_str is the unit_id, unit_name or id of a unit in
         the taxonomy, False otherwise.
 
+        The search for the unit can be restricted by specifying attr as one
+        of 'unit_id', 'unit_name', or 'id'.
+
         Args:
-            unit_str : string
+            unit_str: str
                 can be unit_id, unit_name or id
+            attr: str, default None
+                checks only specified attribute, can be 'unit_id', 'unit_name',
+                or 'id'
 
-        Returns boolean
+        Returns:
+            boolean
+
+        Raises:
+            ValueError if attr is not valid attribute
         """
-        return (unit_str in self._units.keys() or \
-                unit_str in self._by_id().keys() or \
-                unit_str in self._by_unit_name().keys())
+        if not attr:
+            # check for any attribute
+            return (unit_str in self._units.keys() or \
+                    unit_str in self._by_id().keys() or \
+                    unit_str in self._by_unit_name().keys())
+        elif attr not in {'unit_id', 'unit_name', 'id'}:
+            raise ValueError('{} is not a valid unit attribute, must be one of'
+                             '"unit_id", "unit_name" or "id"'
+                             .format(attr))
+        else:
+            if attr=='unit_id':
+                return unit_str in self._units.keys()
+            elif attr=='unit_name':
+                return unit_str in self._by_unit_name().keys()
+            elif attr=='id':
+                return unit_str in self._by_id().keys()
 
-    def get_unit(self, unit_str):
+    def get_unit(self, unit_str, attr=None):
         """
         Returns the unit with unit_id, unit_name or id is given by unit_str.
 
+        The search for the unit can be restricted by specifying attr as one
+        of 'unit_id', 'unit_name', or 'id'.
+
         Args:
-            unit_str : string
+            unit_str: str
                 can be unit_id, unit_name or id
+            attr: str, default None
+                checks only specified attribute, can be 'unit_id', 'unit_name',
+                or 'id'
 
         Returns:
-            unit : dict
+            unit: dict
 
         Raises:
-            KeyError if unit_str is not in the taxonomy
+            ValueError if unit_str is not a value for a unit in the taxonomy
         """
         found = False
-        if self.is_unit(unit_str):
-            # find unit_id
-            try:
-                unit = self._units[unit_str]
-                found = True
-            except:
+        if not attr:
+            # search by unit_id, unit_name or id
+            if self.is_unit(unit_str, attr):
+                # find unit_id
+                try:
+                    unit = self._units[unit_str]
+                    found = True
+                except:
+                    if unit_str in self._by_id():
+                        unit_id = self._by_id()[unit_str]
+                        unit = self._units[unit_id]
+                        found = True
+                    elif unit_str in self._by_unit_name():
+                        unit_id = self._by_unit_name()[unit_str]
+                        unit = self._units[unit_id]
+                        found = True
+            if not found:
+                raise ValueError("{} is not a valid unit_id, unit_name or id"
+                                .format(unit_str))
+                return None
+
+        elif attr not in {'unit_id', 'unit_name', 'id'}:
+            raise ValueError('{} is not a recognized unit attribute'
+                             .format(attr))
+        else:
+            # valid attr, search for unit_str in attr's values
+            if attr=='unit_id':
+                if unit_str in self._units.keys():
+                    unit = self._units[unit_str]
+                    found = True
+            elif attr=='unit_name':
+                if unit_str in self._by_unit_name():
+                    unit_id = self._by_unit_name()[unit_str]
+                    unit = self._units[unit_id]
+                    found = True
+            elif attr=='id':
                 if unit_str in self._by_id():
                     unit_id = self._by_id()[unit_str]
                     unit = self._units[unit_id]
                     found = True
-                elif unit_str in self._by_unit_name():
-                    unit_id = self._by_unit_name()[unit_str]
-                    unit = self._units[unit_id]
-                    found = True
-
-        if not found:
-            raise KeyError("{} is not a valid unit_id, unit_name or id"
-                            .format(unit_str))
-            return None
-        else:
-            return unit
+            if not found:
+                raise ValueError("{} is not a valid value for {}"
+                                .format(unit_str, attr))
+                return None
+            else:
+                return unit

--- a/oblib/tests/test_taxonomy_units.py
+++ b/oblib/tests/test_taxonomy_units.py
@@ -30,8 +30,10 @@ class TestTaxonomyUnits(unittest.TestCase):
         self.assertFalse(tax.is_unit("acre", "unit_name"))
         self.assertFalse(tax.is_unit("acre", "id"))
 
-        self.assertRaises(tax.is_unit("acre", "unit_nickname"))
-        self.assertRaises(tax.is_unit("acre", attr=14))
+        with self.assertRaises(ValueError):
+            found = tax.is_unit("acre", "unit_nickname")
+        with self.assertRaises(ValueError):
+            found = tax.is_unit("acre", attr=14)
 
         self.assertTrue(tax.is_unit("oz"))
         self.assertTrue(tax.is_unit("rad"))

--- a/oblib/tests/test_taxonomy_units.py
+++ b/oblib/tests/test_taxonomy_units.py
@@ -23,17 +23,24 @@ tax = taxonomy_units.TaxonomyUnits()
 
 class TestTaxonomyUnits(unittest.TestCase):
 
-    def test_get_all_units(self):
-        self.assertEqual(len(tax.get_all_units()), 296)
-
     def test_is_unit(self):
         self.assertTrue(tax.is_unit("acre"))
+        self.assertTrue(tax.is_unit("acre"), attr=None)
+        self.assertTrue(tax.is_unit("acre", "unit_id"))
+        self.assertFalse(tax.is_unit("acre", "unit_name"))
+        self.assertFalse(tax.is_unit("acre", "id"))
+
+        self.assertRaises(tax.is_unit("acre", "unit_nickname"))
+        self.assertRaises(tax.is_unit("acre", attr=14))
+
         self.assertTrue(tax.is_unit("oz"))
         self.assertTrue(tax.is_unit("rad"))
         self.assertFalse(tax.is_unit("acrre"))
         self.assertFalse(tax.is_unit("ozz"))
         self.assertFalse(tax.is_unit("rrad"))
         self.assertTrue(tax.is_unit("Acre"))
+        self.assertTrue(tax.is_unit("Acre", "unit_name"))
+        self.assertTrue(tax.is_unit("u00001", "id"))
         self.assertTrue(tax.is_unit("Ounce"))
         self.assertTrue(tax.is_unit("Radian"))
         self.assertFalse(tax.is_unit("acrre"))

--- a/oblib/tests/test_taxonomy_units.py
+++ b/oblib/tests/test_taxonomy_units.py
@@ -25,7 +25,7 @@ class TestTaxonomyUnits(unittest.TestCase):
 
     def test_is_unit(self):
         self.assertTrue(tax.is_unit("acre"))
-        self.assertTrue(tax.is_unit("acre"), attr=None)
+        self.assertTrue(tax.is_unit("acre", attr=None))
         self.assertTrue(tax.is_unit("acre", "unit_id"))
         self.assertFalse(tax.is_unit("acre", "unit_name"))
         self.assertFalse(tax.is_unit("acre", "id"))


### PR DESCRIPTION
Can specify kwarg `attr='unit_id', 'unit_name' or 'id' (default None)` to restrict searching for the desired unit.