### PR TITLE
Fixes for issues #60 #92 #142 and #144

### DIFF
--- a/oblib/data_model.py
+++ b/oblib/data_model.py
@@ -586,7 +586,7 @@ class Fact(object):
 
         if isinstance( self.value, datetime.datetime):
             # Format dates:
-            value_literal = self.value.strftime("%Y-%m-%dT%H:%M:%S")
+            value_literal = self.value.isoformat(sep='T')
         elif isinstance( self.value, bool):
             # booleans are written as boolean literals
             value_literal = self.value
@@ -1115,7 +1115,7 @@ class OBInstance(object):
           needed to provide full context for the named concept. i.e. if it
           provides either a valid duration or a valid instant, whichever
           the concept requires, and it also provides valid values for each and
-          every dimension (Axis) required by the table where the concepr resides.
+          every dimension (Axis) required by the table where the concept resides.
         Raises:
           OBContextError explaining what is wrong, if some needed information
           is missing or invalid.

--- a/oblib/data_model.py
+++ b/oblib/data_model.py
@@ -456,7 +456,7 @@ class Context(object):
         """
         Returns:
           A JSON-style dictionary object containing this context's fields
-          (entity, period, and extra dimensions)
+          (entity, period, and extra dimensions).
         """
         aspects = {"entity": self.entity}
 
@@ -572,7 +572,8 @@ class Fact(object):
         """
         Returns:
           a JSON-style dict representing this Fact and all its fields in XBRL
-          JSON format.
+          JSON format. All values are strings except for True, False, and None
+          which are literals. (see issue #142)
         """
         aspects = self.context._toJSON()
         aspects["concept"] = self.concept_name
@@ -584,11 +585,19 @@ class Fact(object):
                 aspects["precision"] = str(self.precision)
 
         if isinstance( self.value, datetime.datetime):
-            value_str = self.value.strftime("%Y-%m-%dT%H:%M:%S")
+            # Format dates:
+            value_literal = self.value.strftime("%Y-%m-%dT%H:%M:%S")
+        elif isinstance( self.value, bool):
+            # booleans are written as boolean literals
+            value_literal = self.value
+        elif isinstance( self.value, type(None)):
+            # So are Nones:
+            value_literal = self.value
         else:
-            value_str = str(self.value)
+            # All else gets converted to string:
+            value_literal = str(self.value)
         return { "aspects": aspects,
-                 "value": value_str}
+                 "value": value_literal}
 
 
 class Concept(object):

--- a/oblib/data_model.py
+++ b/oblib/data_model.py
@@ -879,22 +879,20 @@ class OBInstance(object):
         self._dev_validation_off = dev_validation_off
         self._all_my_concepts = {}
 
-        if entrypoint_name == "All":
-            self._init_all_entrypoint()
-        else:
-            if not self.ts.is_entrypoint(entrypoint_name):
-                raise OBNotFoundError(
-                    "There is no Orange Button entrypoint named {}.".format(
-                        entrypoint_name))
 
-            # This gives me the list of every concept that could ever be
-            # included in the document.
-            concept_list = self.ts.get_entrypoint_concepts(entrypoint_name)
-            self._initialize_concepts(concept_list)
+        if not self.ts.is_entrypoint(entrypoint_name):
+            raise OBNotFoundError(
+                "There is no Orange Button entrypoint named {}.".format(
+                    entrypoint_name))
 
-            # Get the relationships (this comes from solar_taxonomy/documents/
-            #  <entrypoint>/<entrypoint><version>_def.xml)
-            self.relations = self.ts.get_entrypoint_relationships(entrypoint_name)
+        # This gives me the list of every concept that could ever be
+        # included in the document.
+        concept_list = self.ts.get_entrypoint_concepts(entrypoint_name)
+        self._initialize_concepts(concept_list)
+
+        # Get the relationships (this comes from solar_taxonomy/documents/
+        #  <entrypoint>/<entrypoint><version>_def.xml)
+        self.relations = self.ts.get_entrypoint_relationships(entrypoint_name)
 
         # Search through the relationships to find all of the tables, their
         # axes, and parent/child relationships between concepts:
@@ -926,28 +924,6 @@ class OBInstance(object):
             else:
                 new_concept = Concept(self.taxonomy, concept_name)
             self._all_my_concepts[concept_name] = new_concept
-
-
-    def _init_all_entrypoint(self):
-        """
-        Initializes the Instance to allow all concepts. Called by the constructor,
-        client code should not call this.
-        Args: None
-        Returns: None
-        """
-        # take every concept from taxonomy
-        every_concept = []
-        for x in self.ts._concepts.values():
-            every_concept.extend(x)
-        self._initialize_concepts(every_concept)
-
-        # Take every relation from taxonomy
-        every_relation = []
-        for x in self.ts._relationships.values():
-            every_relation.extend(x)
-        self.relations = every_relation  # this will contain a lot of duplicates
-        # can't do list(set(list)) when the starting point is a list of dicts
-        # since dicts aren't trivially comparable
 
     def _initialize_tables(self):
         """

--- a/oblib/data_model.py
+++ b/oblib/data_model.py
@@ -256,7 +256,7 @@ class Hypercube(object):
 
         return dimensionValue in axis.domainMembers
 
-    def validate_context(self, context):
+    def _is_valid_context(self, context):
         """
         Args:
           context: a Context instance
@@ -1127,7 +1127,7 @@ class OBInstance(object):
             return True
         return False
 
-    def validate_context(self, concept_name, context):
+    def _is_valid_context(self, concept_name, context):
         """
         Args:
           concept_name: string
@@ -1179,7 +1179,7 @@ class OBInstance(object):
         # required axes, if this concept is on a table:
         table = self.get_table_for_concept(concept_name)
         if table is not None:
-            table.validate_context(context)
+            table._is_valid_context(context)
 
         return True
 
@@ -1344,7 +1344,7 @@ class OBInstance(object):
         if len(self._default_context) > 0:
             context = self._fill_in_context_from_defaults(context, concept)
 
-        if not self.validate_context(concept_name, context):
+        if not self._is_valid_context(concept_name, context):
             raise OBContextError(
                 "Insufficient context for {}".format(concept_name))
 

--- a/oblib/parser.py
+++ b/oblib/parser.py
@@ -83,6 +83,10 @@ class Parser(object):
 
         entrypoints_found = set()
         for entrypoint in self._taxonomy.semantic.get_all_entrypoints():
+            if entrypoint == "All":
+                # Ignore the "All" entrypoint, which matches everything -- we're
+                # looking for a more specific one.
+                continue
             for concept in self._taxonomy.semantic.get_entrypoint_concepts(entrypoint):
                 for doc_concept in doc_concepts:
                     if doc_concept == concept:

--- a/oblib/taxonomy_semantic.py
+++ b/oblib/taxonomy_semantic.py
@@ -213,6 +213,12 @@ class TaxonomySemantic(object):
                     concepts[dirname] = self._load_concepts_file(
                         os.path.join(constants.SOLAR_TAXONOMY_DIR,
                                      "process", dirname, filename))
+
+        # load from "/core/" for the "All" entrypoint:
+        concepts["All"] = self._load_concepts_file(
+            os.path.join(constants.SOLAR_TAXONOMY_DIR, "core",
+                             "solar_all_2018-03-31_r01_pre.xml"))
+
         return concepts
 
     def _load_relationships_file(self, fn):
@@ -241,6 +247,11 @@ class TaxonomySemantic(object):
             for filename in os.listdir(os.path.join(constants.SOLAR_TAXONOMY_DIR, "process", dirname)):
                 if 'def.' in filename:
                     relationships[dirname] = self._load_relationships_file(os.path.join("process", dirname, filename))
+
+        # load from "/core/" for the "All" entrypoint:
+        relationships["All"] = self._load_relationships_file(
+            os.path.join(constants.SOLAR_TAXONOMY_DIR, "core",
+                         "solar_all_2018-03-31_r01_def.xml"))
 
         return relationships
 

--- a/oblib/tests/test_data_model.py
+++ b/oblib/tests/test_data_model.py
@@ -971,6 +971,11 @@ class TestDataModelEntrypoint(unittest.TestCase):
         self.assertIn("units", root.nsmap)
         self.assertIn("us-gaap", root.nsmap)
 
+    def test_all_entrypoint(self):
+        # Passing the string "All" to OBInstance should give me access to every concept
+        # instead of restricting it to an entrypoint.
+        doc = data_model.OBInstance("All", self.taxonomy)
+        self.assertEqual(len(doc._all_my_concepts), 4230) # Every concept!
 
     # TODO lots more tests for using get(), especially with partial context arguments.
 

--- a/oblib/tests/test_data_model.py
+++ b/oblib/tests/test_data_model.py
@@ -871,7 +871,6 @@ class TestDataModelEntrypoint(unittest.TestCase):
         # Issue #77 - all json fields should be strings other than None which should convert
         # a JSON null literal.  e.g. numbers should be "100" not 100
         # Issue #142 -- and booleans should convert to a JSON true/false literal.
-
         """
         "key": false - correct
         "key": "false" - incorrect
@@ -890,6 +889,9 @@ class TestDataModelEntrypoint(unittest.TestCase):
         "key": "Null" - incorrect
         "key": "None" - incorrect
         """
+        # NOTE: for v1.0, incorrect fields are processed on input but not on output.
+        # This decision may be revisited in a future release.
+
         
         doc = data_model.OBInstance("System", self.taxonomy, dev_validation_off=True)
         now = datetime.now()

--- a/oblib/tests/test_data_model.py
+++ b/oblib/tests/test_data_model.py
@@ -125,22 +125,22 @@ class TestDataModelEntrypoint(unittest.TestCase):
                                              TestConditionAxis = "solar:StandardTestConditionMember",
                                              duration = "forever")
 
-        self.assertTrue( doc.validate_context("solar:DeviceCost",
+        self.assertTrue( doc._is_valid_context("solar:DeviceCost",
                                               instantContext))
         # A context with a duration instead of an instant should also be
         # rejected:
         with self.assertRaises(OBContextError):
-            doc.validate_context("solar:DeviceCost", durationContext)
+            doc._is_valid_context("solar:DeviceCost", durationContext)
 
         # solar:ModuleNameplateCapacity has period_type duration.
         # A context with an instant instead of a duration should also be
         # rejected:
         with self.assertRaises(OBContextError):
-            doc.validate_context("solar:ModuleNameplateCapacity", instantContext)
-        self.assertTrue( doc.validate_context("solar:ModuleNameplateCapacity",
+            doc._is_valid_context("solar:ModuleNameplateCapacity", instantContext)
+        self.assertTrue( doc._is_valid_context("solar:ModuleNameplateCapacity",
                                               durationContext))
 
-    def test_validate_context_axes(self):
+    def test_is_valid_context_axes(self):
         doc = data_model.OBInstance("CutSheet", self.taxonomy)
 
         # The context must also provide all of the axes needed to place the
@@ -149,22 +149,22 @@ class TestDataModelEntrypoint(unittest.TestCase):
         # DeviceCost is on the CutSheetDetailsTable so it needs a value
         # for ProductIdentifierAxis and TestConditionAxis.
         with self.assertRaises(OBContextError):
-            doc.validate_context("solar:DeviceCost", {})
+            doc._is_valid_context("solar:DeviceCost", {})
 
         context = data_model.Context(instant = datetime.now(),
                           ProductIdentifierAxis = "placeholder",
                           TestConditionAxis = "solar:StandardTestConditionMember")
-        self.assertTrue(doc.validate_context("solar:DeviceCost", context))
+        self.assertTrue(doc._is_valid_context("solar:DeviceCost", context))
 
         badContext = data_model.Context(instant = datetime.now(),
                              TestConditionAxis = "solar:StandardTestConditionMember")
         with self.assertRaises(OBContextError):
-            doc.validate_context("solar:DeviceCost", badContext)
+            doc._is_valid_context("solar:DeviceCost", badContext)
 
         badContext = data_model.Context(instant = datetime.now(),
                              ProductIdentifierAxis = "placeholder")
         with self.assertRaises(OBContextError):
-            doc.validate_context("solar:DeviceCost", badContext)
+            doc._is_valid_context("solar:DeviceCost", badContext)
 
         # How do we know what are valid values for ProductIdentifierAxis and
         # TestConditionAxis?  (I think they are meant to be UUIDs.)
@@ -182,17 +182,17 @@ class TestDataModelEntrypoint(unittest.TestCase):
                           ProductIdentifierAxis = "placeholder",
                           InverterPowerLevelPercentAxis = 'solar:InverterPowerLevel100PercentMember')
 
-        self.assertTrue(doc.validate_context(concept, context))
+        self.assertTrue(doc._is_valid_context(concept, context))
 
         badContext = data_model.Context(instant = datetime.now(),
                              InverterPowerLevelPercentAxis = 'solar:InverterPowerLevel100PercentMember')
         with self.assertRaises(OBContextError):
-            doc.validate_context(concept, badContext)
+            doc._is_valid_context(concept, badContext)
 
         badContext = data_model.Context(instant = datetime.now(),
                              ProductIdentifierAxis = "placeholder")
         with self.assertRaises(OBContextError):
-            doc.validate_context(concept, badContext)
+            doc._is_valid_context(concept, badContext)
 
     def test_set_separate_dimension_args(self):
         # Tests the case where .set() is called correctly.  Use the
@@ -500,7 +500,7 @@ class TestDataModelEntrypoint(unittest.TestCase):
                           InverterPowerLevelPercentAxis = 'solar:StandardTestConditionMember')
         # not a valid value for InverterPowerLevelPercentAxis
         with self.assertRaises(OBContextError):
-            doc.validate_context(concept, context)
+            doc._is_valid_context(concept, context)
 
     def test_reject_missing_or_invalid_units(self):
         # issue #28
@@ -637,7 +637,7 @@ class TestDataModelEntrypoint(unittest.TestCase):
             ProductIdentifierAxis = "placeholder",
             TestConditionAxis = "solar:StandardTestConditionMember",
             instant = datetime.now())
-        self.assertTrue( doc.validate_context("solar:DeviceCost",
+        self.assertTrue( doc._is_valid_context("solar:DeviceCost",
                                               twoAxisContext))
 
         threeAxisContext = data_model.Context(
@@ -648,7 +648,7 @@ class TestDataModelEntrypoint(unittest.TestCase):
         # InverterPowerLevelPercentAxis is a valid axis and this is a valid value for it,
         # but the table that holds DeviceCost doesn't want this axis:
         with self.assertRaises(OBContextError):
-            doc.validate_context("solar:DeviceCost", threeAxisContext)
+            doc._is_valid_context("solar:DeviceCost", threeAxisContext)
 
     def test_set_default_context_values(self):
         # Test setting default values, for example something like:

--- a/oblib/tests/test_taxonomy_semantic.py
+++ b/oblib/tests/test_taxonomy_semantic.py
@@ -117,7 +117,8 @@ class TestTaxonomySemantic(unittest.TestCase):
         self.assertEqual(len(tax.get_all_type_names()), 91)
 
     def test_get_all_entrypoints(self):
-        self.assertEqual(len(tax.get_all_entrypoints()), 159)
+        # 159 named entry points plus 1 for the "All" entry point:
+        self.assertEqual(len(tax.get_all_entrypoints()), 160)
 
     def test_get_entrypoint_relationships(self):
         self.assertIsNone(tax.get_entrypoint_relationships("Arggh"))


### PR DESCRIPTION
#60  : replaced OBException and subclasses with OBError and subclasses in data_model.

#92 : renamed data_model.OBInstance.validate_context() to _is_valid_context().

#142 : forced fact values of `true`, `false`, and `null` to be exported to JSON as true/false/null literals, all other values to be strings.

#144 : Removed special-case code from data_model that was used to create 'All' entrypoint by combining other entrypoints. Made taxonomy_semantic create 'All' entrypoint by reading core/solar_all_2018-03-31_r01_def.xml instead.